### PR TITLE
Fix Parallel pool size of 1 limitation

### DIFF
--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -88,8 +88,8 @@ function ngfmVis(varargin)
     % get the worker's queue back for main to use
     % This queue is for main to send data over to allow the async worker
     % to terminate gracefully, avoiding serial port and thread lockups
-    [data, data_available] = poll(dataQueue, 1);
-    if(data_available)
+    [data, dataAvailable] = poll(dataQueue, 1);
+    if(dataAvailable)
         workerQueue = data;
     end
 
@@ -104,8 +104,8 @@ function ngfmVis(varargin)
     % main loop
     while (~done)
         % check if the worker said it's done
-        [data, kill_msg] = poll(workerDoneQueue);
-        if(kill_msg)
+        [data, dataAvailable] = poll(workerDoneQueue);
+        if(dataAvailable)
             if(data == 0)
                 fprintf('Serial Port or File closed\n');
                 done = 1;
@@ -114,8 +114,8 @@ function ngfmVis(varargin)
         end
         
         % check if there's data to read
-        [data, data_available] = poll(dataQueue, 1); 
-        if(data_available)
+        [data, dataAvailable] = poll(dataQueue, 1); 
+        if(dataAvailable)
             if(isa(data,'cell'))
                 fprintf('%s\n', char(data));
                 done = 1;

--- a/sourceMonitor.m
+++ b/sourceMonitor.m
@@ -3,8 +3,12 @@
 % It's purpose is to capture data from the source (port mostly)
 % unencumbered from the rest of the program and send that data back to the
 % main thread.
-function sourceMonitor(qConstant, data_queue, kill_queue, device, devicePath, serialBufferLen, dle, stx, etx)
-    q = qConstant.Value;
+function sourceMonitor(workerQueueConstant, dataQueue, kill_queue, device, devicePath, serialBufferLen, dle, stx, etx)
+    % construct queue that main can use to talk to this worker
+    % and send it back for it to use
+    workerQueue = workerQueueConstant.Value;
+    send(dataQueue, workerQueue);
+    
     finished = 0;
     serialBuffer = zeros(serialBufferLen);
     serialCounter = 1;
@@ -18,21 +22,21 @@ function sourceMonitor(qConstant, data_queue, kill_queue, device, devicePath, se
             flushinput(s);
         catch exception
             vec = {exception.message};
-            send(data_queue, vec);
+            send(dataQueue, vec);
             return;
         end
     else
         if (exist(devicePath, 'file') == 2)
             s = fopen(devicePath);
         else
-            send(data_queue, 2);
+            send(dataQueue, 2);
             return;
         end
     end
     
     while (~finished)
         % Check for a kill message from main thread
-        [~, OK] = poll(q);
+        [~, OK] = poll(workerQueue);
         if(OK)
             % properly close up port/file
             fclose(s);
@@ -53,7 +57,7 @@ function sourceMonitor(qConstant, data_queue, kill_queue, device, devicePath, se
                 fclose(s);
                 delete(s);
                 clear s
-                send(data_queue, 3);
+                send(dataQueue, 3);
             elseif (serialCounter+count > serialBufferLen)
                 fprintf('Serial buffer overfilled');
             else
@@ -74,7 +78,7 @@ function sourceMonitor(qConstant, data_queue, kill_queue, device, devicePath, se
                     serialBuffer(1:serialCounter-1248) = serialBuffer(1249:serialCounter);
                     serialCounter = serialCounter - 1248;
                     % send to data queue
-                    send(data_queue, tempPacket); 
+                    send(dataQueue, tempPacket); 
                 else
                     serialBuffer(1:serialBufferLen-1)=serialBuffer(2:serialBufferLen);
                     serialCounter = serialCounter - 1;

--- a/sourceMonitor.m
+++ b/sourceMonitor.m
@@ -3,7 +3,7 @@
 % It's purpose is to capture data from the source (port mostly)
 % unencumbered from the rest of the program and send that data back to the
 % main thread.
-function sourceMonitor(workerQueueConstant, dataQueue, kill_queue, device, devicePath, serialBufferLen, dle, stx, etx)
+function sourceMonitor(workerQueueConstant, dataQueue, workerDoneQueue, device, devicePath, serialBufferLen, dle, stx, etx)
     % construct queue that main can use to talk to this worker
     % and send it back for it to use
     workerQueue = workerQueueConstant.Value;
@@ -44,7 +44,7 @@ function sourceMonitor(workerQueueConstant, dataQueue, kill_queue, device, devic
             clear s
             
             % send termination value
-            send(kill_queue, 0);
+            send(workerDoneQueue, 0);
             finished = 1;
             continue;
         else


### PR DESCRIPTION
# Abstract
This PR fixes #35. The way I initially constructed the source monitor on an async worker follows [this post](https://www.mathworks.com/matlabcentral/answers/424145-how-can-i-send-data-on-the-fly-to-a-worker-when-using-parfeval) and was a bit hacky and didn't work on parallel pools larger than 1. I've been meaning to fix it and have gotten around to it.

## What I changed

- Instead of using an anonymous function to have the worker construct a queue and returned immediately for later workers to reference, I just have sourceMonitor() construct the queue and returned over the dataQueue that's already constructed. 
 - Renamed the names of the queue to not be weird and follow camelCase convention. 