### PR TITLE
Fix realtime

### DIFF
--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -101,7 +101,8 @@ function ngfmVis(varargin)
     
     % main loop
     while (~done)
-        % check if the worker said it's done
+        % If there is anything in this queue then the worker is done
+        % Print the associated code's message
         [data, dataAvailable] = poll(workerDoneQueue);
         if(dataAvailable)
             if(data == 0)
@@ -134,17 +135,13 @@ function ngfmVis(varargin)
                     fprintf('%s\n', char(data));
                     done = 1;
                     break;
-%                 elseif(data == 3)
-%                     fprintf('Fread returned zero\n');
-%                     done = 1;
-%                     break; %change to break
                 else
                 % parse packet
-                testpack = getDataPacket(dataPacket, data, inputOffset);
+                tempPacket = getDataPacket(dataPacket, data, inputOffset);
 
-                fprintf('Packet parser PID = %d.\n', testpack.pid);
+                fprintf('Packet parser PID = %d.\n', tempPacket.pid);
 
-                [testpack, magData, hkData] = interpretData( testpack, magData, hkData, hk);
+                [tempPacket, magData, hkData] = interpretData( tempPacket, magData, hkData, hk);
                 end
                 
             end
@@ -153,7 +150,7 @@ function ngfmVis(varargin)
             % until we can put in a proper close request callback
             try
                 [fig, closereq, key, debugData] = ...
-                    ngfmPlotUpdate(fig, testpack, magData, hkData);
+                    ngfmPlotUpdate(fig, tempPacket, magData, hkData);
             catch exception
                 closereq = 1;
                 fprintf('Plot error: %s\n', exception.message)
@@ -187,8 +184,6 @@ function ngfmVis(varargin)
         end
 
         if(~isempty(key))
-%             if strcmp(key,'`')
-%                 debugData = ~debugData;
             if strcmp(p.Results.device, 'serial')
                 %have this sent over serial worker
                 fwrite(s,k);

--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -127,7 +127,6 @@ function ngfmVis(varargin)
             else
                 numToRead = 1;
             end
-            
             % process all available packets at once
             for i = 1:numToRead
                 [data, ~] = poll(dataQueue, 1); 
@@ -164,8 +163,6 @@ function ngfmVis(varargin)
                 end
             end
         end
-
-        pause(0.001);
         
         % check if the user closed the main window
         if (closereq == 1)

--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -108,6 +108,14 @@ function ngfmVis(varargin)
                 fprintf('Serial Port or File closed\n');
                 done = 1;
                 continue;
+            elseif(data == 1)
+                fprintf('Error: File not found\n');
+                done = 1;
+                continue;
+            elseif(data == 2)
+                fprintf('Fread returned zero\n');
+                done = 1;
+                continue;
             end
         end
         
@@ -125,15 +133,11 @@ function ngfmVis(varargin)
                 if(isa(data,'cell'))
                     fprintf('%s\n', char(data));
                     done = 1;
-                    break; %change to break
-                elseif(data == 2)
-                    fprintf('Error: File not found\n');
-                    done = 1;
-                    break; %change to break
-                elseif(data == 3)
-                    fprintf('Fread returned zero\n');
-                    done = 1;
-                    break; %change to break
+                    break;
+%                 elseif(data == 3)
+%                     fprintf('Fread returned zero\n');
+%                     done = 1;
+%                     break; %change to break
                 else
                 % parse packet
                 testpack = getDataPacket(dataPacket, data, inputOffset);

--- a/sourceMonitor.m
+++ b/sourceMonitor.m
@@ -21,6 +21,7 @@ function sourceMonitor(workerQueueConstant, dataQueue, workerDoneQueue, device, 
             fopen(s);
             flushinput(s);
         catch exception
+            % Send error with message
             vec = {exception.message};
             send(dataQueue, vec);
             return;
@@ -29,7 +30,8 @@ function sourceMonitor(workerQueueConstant, dataQueue, workerDoneQueue, device, 
         if (exist(devicePath, 'file') == 2)
             s = fopen(devicePath);
         else
-            send(dataQueue, 2);
+            % Send error code 2, 'File not found'
+            send(workerDoneQueue, 1);
             return;
         end
     end
@@ -57,7 +59,7 @@ function sourceMonitor(workerQueueConstant, dataQueue, workerDoneQueue, device, 
                 fclose(s);
                 delete(s);
                 clear s
-                send(dataQueue, 3);
+                send(workerDoneQueue, 2);
             elseif (serialCounter+count > serialBufferLen)
                 fprintf('Serial buffer overfilled');
             else
@@ -84,8 +86,8 @@ function sourceMonitor(workerQueueConstant, dataQueue, workerDoneQueue, device, 
                     serialCounter = serialCounter - 1;
                 end
             end
-%             pause(0.005); % This sets fread to ~175hz on my machine
-            pause(0.01);
+            pause(0.005); % This sets fread to ~175hz on my machine
+%             pause(0.01);
         end
     end
 end


### PR DESCRIPTION
# Abstract

This PR fixes #47. The real-time portion of the program broke since adding in the async worker pushing packets to the queue stuff. Since the worker pushes packets to the queue faster than the main thread can visualize them, it falls behind and the program starts showing "what happened" rather than "what's happening now". This especially becomes an issue when a blocking function is called (i.e. browse for a file) is called for a while and the queue fills up a bit. 

## What I changed
- Main thread takes all the available packets in the queue, parses them, interprets them, and then plots once
  - reading from a file is always 1 packet at a time
- Error codes that the worker sends, things like not finding the file, fread returning zero, etc are now sent over the workerDoneQueue rather than the data queue. This makes more sense and also terminates the program faster

## Testing
Since I don't have unit tests yet, I printed to the console to see if it was working correctly.

### Reading from serial, no main thread pausing
<img width="197" alt="no_pause" src="https://user-images.githubusercontent.com/24396097/71196055-d424cc00-2254-11ea-8c5d-886de2af767a.png">
The program plots as fast as it can and the source monitor reads at about ~175hz. As shown, it processes 1-2 packets every time with a few more every once in awhile

### Reading from serial, 10ms main thread pause
<img width="195" alt="10ms_pause" src="https://user-images.githubusercontent.com/24396097/71196147-07675b00-2255-11ea-994a-ffdd57824182.png">
I deliberately slowed down the plotting by making the main thread wait 10ms after each plot. This would simulate the serial coming in at a faster rate or if something in the plotting code slows down. As shown, it processes a few more packets each time, but still stays current.

### Reading from serial, multi-second pause
<img width="187" alt="long_pause" src="https://user-images.githubusercontent.com/24396097/71196245-44cbe880-2255-11ea-9477-59fd02d93ae4.png">
This test case represents the user invoking a blocking function, like browsing for a file (i.e. uigetfile()). They can block the program for many seconds, so then a lot of packets get processed at once then it returns back to a few.

 ### Reading from a file
<img width="194" alt="read_from_file" src="https://user-images.githubusercontent.com/24396097/71196399-9b392700-2255-11ea-8985-43c736b9ba87.png">
Always 1