### PR TITLE
Custom Sampling rate

### DIFF
--- a/ngfmHardwareCmd.m
+++ b/ngfmHardwareCmd.m
@@ -286,9 +286,7 @@ function FeedbackBtnCallback(hObject, ~)
             end
         end
     end
-
     setappdata(handles.fig, 'key', arr);
-
 end
 
 % Send Feedback Calibration Button Callback

--- a/ngfmLoadConstants.m
+++ b/ngfmLoadConstants.m
@@ -3,6 +3,7 @@ assumedSamplingRate = 100;
 secondsToDisplay = 10;
 secondsToWelch = 60*60;
 hkPacketsToDisplay = 100;
+targetSamplingHz = 150;
 
 nfft = 8*2048;
 

--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -79,9 +79,10 @@ function ngfmVis(varargin)
     
     % main loop
     while (~done)
-        % If there is anything in this queue then the worker is done
-        % Print the error or associated code's message, begin program exit process
-        [workerDoneQueueData, workerDoneQueueDataAvail] = poll(workerCommQueue);
+        % If the worker is done, the print the error or associated code's
+        %   message, begin program exit process
+        % Else it is the current sampling rate
+        [workerDoneQueueData, workerDoneQueueDataAvail] = poll(workerCommQueue, 0.01);
         if(workerDoneQueueDataAvail)
             if(isa(workerDoneQueueData,'cell'))
                 fprintf('%s\n', char(workerDoneQueueData));
@@ -94,7 +95,6 @@ function ngfmVis(varargin)
             elseif(isa(workerDoneQueueData,'double'))
                 fprintf('Sampling Rate: %3.2f\n', workerDoneQueueData);
             end
-            
         end
         
         % check if there's data to read
@@ -114,9 +114,6 @@ function ngfmVis(varargin)
                     fprintf('Packet parser PID = %d.\n', dataPacket.pid);
                     [dataPacket, magData, hkData] = interpretData(dataPacket, magData, hkData);
                 end
-%                 if(packetQueueDataAvail) % CWB debug
-%                     fprintf('%3.7f\n', packetQueueData)
-%                 end
             end
 
             % put a try catch in for now to handle the window being closed
@@ -197,6 +194,7 @@ function [F, packetQueue, workerCommQueue, workerQueue] = ...
     
     % Pollable data queue that the worker will use to send data over
     % that tells the main thread it is done executing
+    % and sends the sampling rate over
     workerCommQueue = parallel.pool.PollableDataQueue;
     
     % call sourceMonitor asynchronously

--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -22,7 +22,6 @@ function ngfmVis(varargin)
     parse(p,varargin{:});
 
     % load vars
-%     loadconfigxml;
     ngfmLoadConstants;
     magData = zeros(3,numSamplesToStore);
     hkData = zeros(12,hkPacketsToDisplay);
@@ -62,7 +61,6 @@ function ngfmVis(varargin)
     
     % set up GUI
     fig = ngfmPlotInit();
-    drawnow();
     
     % setup the parallel stuff. Construct queues and call sourceMonitor
     % asynchronously

--- a/ngfmVis.m
+++ b/ngfmVis.m
@@ -108,6 +108,9 @@ function ngfmVis(varargin)
                     fprintf('Packet parser PID = %d.\n', dataPacket.pid);
                     [dataPacket, magData, hkData] = interpretData( dataPacket, magData, hkData);
                 end
+%                 if(packetQueueDataAvail) % CWB debug
+%                     disp(packetQueueData)
+%                 end
             end
 
             % put a try catch in for now to handle the window being closed

--- a/sourceMonitor.m
+++ b/sourceMonitor.m
@@ -131,7 +131,6 @@ function sourceMonitor(workerQueueConstant, packetQueue, workerCommQueue, ...
             [pauseTime, samplingRates] = changeSamplingRate(avgSamplingHz, ...
                 targetSamplingHz, tolerance, pauseTime, numSampleRates);
             avgSamplingHzToSend = avgSamplingHz;
-%             send(workerCommQueue,avgSamplingHz); % debug
         end
         pause(pauseTime);
     end

--- a/sourceMonitor.m
+++ b/sourceMonitor.m
@@ -43,8 +43,8 @@ function sourceMonitor(workerQueueConstant, packetQueue, workerCommQueue, ...
     end
     
     % start timer
-    % This will send current sampling rate over the workerCommQueue for the
-    % main program to use every 1 second.
+    % Its callback will send the current sampling rate over the
+    % workerCommQueue every 1 second.
     t = timer('ExecutionMode', 'fixedRate', ...
               'TimerFcn', @timerCallback, ...
               'Period', 1, 'StartDelay', 2);
@@ -140,7 +140,7 @@ function sourceMonitor(workerQueueConstant, packetQueue, workerCommQueue, ...
     end
 end
 
-% Adds most recent timeElapsed to the array, computes new mean
+% Adds most recent timeElapsed to the array, compute new mean
 function [avgSamplingHz, samplingRates] = getAvgSamplingHz(samplingRates, timeElapsed)
     samplingRates(1,2:length(samplingRates)) = ...
         samplingRates(1,1:(length(samplingRates)-1));
@@ -152,6 +152,7 @@ end
 % otherwise return same rate
 function [pauseTime, samplingRates] = changeSamplingRate(avgSamplingHz, ...
     targetSamplingHz, tolerance, pauseTime, numSampleRates)
+
     rateDifference = 1 - (avgSamplingHz/targetSamplingHz);
     if(abs(rateDifference) > tolerance)
         if(rateDifference < 0)
@@ -160,5 +161,6 @@ function [pauseTime, samplingRates] = changeSamplingRate(avgSamplingHz, ...
             pauseTime = pauseTime - (pauseTime*rateDifference);
         end
     end
+    % clear sampling rates array
     samplingRates = zeros(1, numSampleRates);
 end


### PR DESCRIPTION
# Abstract
`sourceMonitor` can now sample the source at a user specified rate.

## What I changed
- Instead of pausing for a hard coded time, `sourceMonitor` now times how often it is calling `fread()` and adjusts it to meet the user specified Hz rate. 
  - For example, if the specified target sampling rate is 150 Hz and `fread()` is being called at 100 Hz then it'll reduce the amount of time it is pausing at the end of the loop by 66% to meet that rate.
  - A 5% tolerance is included so it's not changing the rate constantly since it's not going to be exactly 150 Hz every time
- A timer in `sourceMonitor` invokes a nested callback every second that sends the current sampling rate to the main worker
- renamed queues, added a timeout to the `workerCommQueue` since it would sit there forever if it didn't get anything 